### PR TITLE
Add flipY option (default true) to TextureWrapper::addCanvas.

### DIFF
--- a/lib/src/textures.dart
+++ b/lib/src/textures.dart
@@ -1,50 +1,59 @@
 part of chronosgl;
 
 class TextureCache {
-  
   Map<String, TextureWrapper> textureCache = new Map<String, TextureWrapper>();
   ChronosGL chronosGL;
   RenderingContext gl;
-  
-  TextureCache(this.chronosGL)
-  {
+
+  TextureCache(this.chronosGL) {
     gl = chronosGL.gl;
   }
 
-  TextureWrapper add(String url, [bool clamp=false]) {
-    return textureCache[url] = new TextureWrapper(this.gl, clamp:clamp, type:TEXTURE_2D);
+  TextureWrapper add(String url, [bool clamp = false]) {
+    return textureCache[url] =
+        new TextureWrapper(this.gl, clamp: clamp, type: TEXTURE_2D);
   }
 
-  void addCube( String name, String prefix, String suffix, {bool clamp:false, String nx:"nx", String px:"px", String ny:"ny", String py:"py", String nz:"nz", String pz:"pz"}) {
-    TextureWrapper tw = textureCache[name] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP);
-    TextureWrapper temp; 
-    temp = textureCache[prefix+nx+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_NEGATIVE_X);
+  void addCube(String name, String prefix, String suffix, {bool clamp: false,
+      String nx: "nx", String px: "px", String ny: "ny", String py: "py",
+      String nz: "nz", String pz: "pz"}) {
+    TextureWrapper tw = textureCache[name] =
+        new TextureWrapper(this.gl, cubemap: true, type: TEXTURE_CUBE_MAP);
+    TextureWrapper temp;
+    temp = textureCache[prefix + nx + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_NEGATIVE_X);
     tw.cubeTextureChildren.add(temp);
-    temp = textureCache[prefix+px+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_POSITIVE_X);
+    temp = textureCache[prefix + px + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_POSITIVE_X);
     tw.cubeTextureChildren.add(temp);
-    temp = textureCache[prefix+ny+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_NEGATIVE_Y);
+    temp = textureCache[prefix + ny + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_NEGATIVE_Y);
     tw.cubeTextureChildren.add(temp);
-    temp = textureCache[prefix+py+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_POSITIVE_Y);
+    temp = textureCache[prefix + py + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_POSITIVE_Y);
     tw.cubeTextureChildren.add(temp);
-    temp = textureCache[prefix+nz+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_NEGATIVE_Z);
+    temp = textureCache[prefix + nz + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_NEGATIVE_Z);
     tw.cubeTextureChildren.add(temp);
-    temp = textureCache[prefix+pz+suffix] = new TextureWrapper(this.gl, cubemap:true, type:TEXTURE_CUBE_MAP_POSITIVE_Z);
+    temp = textureCache[prefix + pz + suffix] = new TextureWrapper(this.gl,
+        cubemap: true, type: TEXTURE_CUBE_MAP_POSITIVE_Z);
     tw.cubeTextureChildren.add(temp);
-    
+
     tw.loaded = true;
   }
-  
+
   TextureWrapper addSolidColor(String url, String fillStyle) {
-    TextureWrapper tw = new TextureWrapper(this.gl, clamp:false);
+    TextureWrapper tw = new TextureWrapper(this.gl, clamp: false);
     tw.loaded = true;
     tw.texture = chronosGL.getUtils().createSolidTexture(fillStyle);
     return textureCache[url] = tw;
   }
 
-  TextureWrapper addCanvas(String url, HTML.CanvasElement canvas) {
-    TextureWrapper tw = new TextureWrapper(this.gl, clamp:false);
+  TextureWrapper addCanvas(String url, HTML.CanvasElement canvas,
+      {bool flipY: true}) {
+    TextureWrapper tw = new TextureWrapper(this.gl, clamp: false);
     tw.loaded = true;
-    tw.texture = chronosGL.getUtils().createTextureFromCanvas(canvas);
+    tw.texture = chronosGL.getUtils().createTextureFromCanvas(canvas, flipY);
     return textureCache[url] = tw;
   }
 
@@ -56,88 +65,76 @@ class TextureCache {
     return textureCache[url];
   }
 
-  void loadAllThenExecute( callBackFunc(  ) ) {
-    
+  void loadAllThenExecute(callBackFunc()) {
     List<Future<HTML.Event>> futures = new List<Future<HTML.Event>>();
-    
-    for( String url in textureCache.keys)
-    {
+
+    for (String url in textureCache.keys) {
       //print(url);
       TextureWrapper textureWrapper = textureCache[url];
-      if( textureWrapper.loaded )
-        continue;
-      
-      futures.add( textureWrapper.image.onLoad.first);
-      
+      if (textureWrapper.loaded) continue;
+
+      futures.add(textureWrapper.image.onLoad.first);
+
       textureWrapper.image.src = url;
-      
-      if( textureWrapper.cubemap)
-        textureWrapper.loaded = true;
+
+      if (textureWrapper.cubemap) textureWrapper.loaded = true;
     }
-    
 
     // TODO: check for error !!
-    Future.wait(futures).then( (List list) {
-      
-      for( String url in textureCache.keys)
-      {
+    Future.wait(futures).then((List list) {
+      for (String url in textureCache.keys) {
         TextureWrapper textureWrapper = textureCache[url];
-        if( textureWrapper.loaded && textureWrapper.type!=TEXTURE_CUBE_MAP)
-          continue;
+        if (textureWrapper.loaded &&
+            textureWrapper.type != TEXTURE_CUBE_MAP) continue;
 
-        if( textureWrapper.cubemap && textureWrapper.type!=TEXTURE_CUBE_MAP)
-          continue;
-        
+        if (textureWrapper.cubemap &&
+            textureWrapper.type != TEXTURE_CUBE_MAP) continue;
+
         gl.bindTexture(textureWrapper.type, textureWrapper.texture);
         gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
         gl.texParameteri(textureWrapper.type, TEXTURE_MAG_FILTER, LINEAR);
-        gl.texParameteri(textureWrapper.type, TEXTURE_MIN_FILTER, LINEAR); // _MIPMAP_NEAREST
-        if( textureWrapper.clamp  )
-        {
-          gl.texParameteri(textureWrapper.type, TEXTURE_WRAP_S, CLAMP_TO_EDGE); // this fixes glitches on skybox seams
+        gl.texParameteri(
+            textureWrapper.type, TEXTURE_MIN_FILTER, LINEAR); // _MIPMAP_NEAREST
+        if (textureWrapper.clamp) {
+          gl.texParameteri(textureWrapper.type, TEXTURE_WRAP_S,
+              CLAMP_TO_EDGE); // this fixes glitches on skybox seams
           gl.texParameteri(textureWrapper.type, TEXTURE_WRAP_T, CLAMP_TO_EDGE);
         }
 
-        if(textureWrapper.type == TEXTURE_CUBE_MAP)
-        {
-          for(TextureWrapper tw in textureWrapper.cubeTextureChildren) {
+        if (textureWrapper.type == TEXTURE_CUBE_MAP) {
+          for (TextureWrapper tw in textureWrapper.cubeTextureChildren) {
             gl.texImage2DImage(tw.type, 0, RGBA, RGBA, UNSIGNED_BYTE, tw.image);
           }
         } else {
-          gl.texImage2DImage(textureWrapper.type, 0, RGBA, RGBA, UNSIGNED_BYTE, textureWrapper.image);
+          gl.texImage2DImage(textureWrapper.type, 0, RGBA, RGBA, UNSIGNED_BYTE,
+              textureWrapper.image);
         }
         //gl.generateMipmap(gl.TEXTURE_2D);
-        
+
         gl.bindTexture(TEXTURE_2D, null);
         textureWrapper.loaded = true;
-        
-        print( "loaded: $url");
+
+        print("loaded: $url");
       }
-      
+
       callBackFunc();
-      
     });
-    
   }
-  
+
   int check() {
     print("check");
     int notReadyCount = 0;
-    for( String url in textureCache.keys )
-    {
+    for (String url in textureCache.keys) {
       //console.log("check: " + url + " : " + textureCache[url].ready);
-      if( ! textureCache[url].loaded)
-      {
+      if (!textureCache[url].loaded) {
         notReadyCount++;
       }
     }
     return notReadyCount;
   }
-
 }
 
 class TextureWrapper {
-  
   Texture texture;
   HTML.ImageElement image = new HTML.ImageElement();
   bool loaded = false;
@@ -145,12 +142,12 @@ class TextureWrapper {
   bool cubemap = false;
   int type;
   List<TextureWrapper> cubeTextureChildren = new List<TextureWrapper>();
-  
-  TextureWrapper(RenderingContext gl, {this.clamp:false, this.cubemap:false, this.type:TEXTURE_2D})
-  {
+
+  TextureWrapper(RenderingContext gl,
+      {this.clamp: false, this.cubemap: false, this.type: TEXTURE_2D}) {
     texture = gl.createTexture();
   }
-  
+
   String toString() {
     return "${image.src} - loaded: $loaded, clamp: $clamp, cubemap: $cubemap, type: $type";
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,41 +1,38 @@
 part of chronosgl;
 
-class Utils
-{
+class Utils {
   ChronosGL chronosGL;
   RenderingContext gl;
   TextureCache textureCache;
-  
-  Utils( this.chronosGL)
-  {
+
+  Utils(this.chronosGL) {
     gl = chronosGL.getRenderingContext();
     textureCache = chronosGL.getTextureCache();
   }
-  
-  Texture createTextureFromCanvas(HTML.CanvasElement canvas)
-  {
+
+  Texture createTextureFromCanvas(HTML.CanvasElement canvas, bool flipY) {
     var texture = gl.createTexture();
     gl.bindTexture(TEXTURE_2D, texture);
+    if (flipY) {
+      gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
+    }
     gl.texImage2DCanvas(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, canvas);
     gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
     gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR); // _MIPMAP_NEAREST
     return texture;
   }
 
-  Texture createSolidTexture(String fillStyle)
-  {
-    HTML.CanvasElement canvas = new HTML.CanvasElement(width:2, height:2);
+  Texture createSolidTexture(String fillStyle) {
+    HTML.CanvasElement canvas = new HTML.CanvasElement(width: 2, height: 2);
     HTML.CanvasRenderingContext2D ctx = canvas.getContext('2d');
     ctx.fillStyle = fillStyle;
-    ctx.fillRect( 0, 0, canvas.width, canvas.height);
-    return createTextureFromCanvas(canvas);
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return createTextureFromCanvas(canvas, false);
   }
-  
+
   Texture createCheckerboardTexture() {
-    var pixels = new Uint8List.fromList([255, 255, 255,
-                                             0,   0,   0,
-                                             0,   0,   0,
-                                             255, 255, 255]);
+    var pixels = new Uint8List.fromList(
+        [255, 255, 255, 0, 0, 0, 0, 0, 0, 255, 255, 255]);
     var texture = gl.createTexture();
     gl.bindTexture(TEXTURE_2D, texture);
     gl.texParameteri(TEXTURE_2D, TEXTURE_WRAP_S, CLAMP_TO_EDGE);
@@ -47,26 +44,28 @@ class Utils
     gl.pixelStorei(UNPACK_ALIGNMENT, 1);
     gl.texImage2DTyped(TEXTURE_2D, 0, RGB, 2, 2, 0, RGB, UNSIGNED_BYTE, pixels);
     return texture;
-}
-  
-  HTML.CanvasElement createCanvas(HTML.CanvasElement canvas, callback(HTML.CanvasRenderingContext2D ctx), [int size=512]) {
-    if( canvas == null)
-      canvas = new HTML.CanvasElement(width:size, height:size);
+  }
+
+  HTML.CanvasElement createCanvas(
+      HTML.CanvasElement canvas, callback(HTML.CanvasRenderingContext2D ctx),
+      [int size = 512]) {
+    if (canvas == null) canvas =
+        new HTML.CanvasElement(width: size, height: size);
     HTML.CanvasRenderingContext2D context = canvas.getContext('2d');
     callback(context);
     return canvas;
   }
-  
-  HTML.CanvasElement createGradientImage2( double time, HTML.CanvasElement canvas)
-  {
+
+  HTML.CanvasElement createGradientImage2(
+      double time, HTML.CanvasElement canvas) {
     int d = 512;
-    return createCanvas( canvas, (HTML.CanvasRenderingContext2D ctx){
-      double sint = Math.sin( time);
-      double n = (sint+1)/2;
+    return createCanvas(canvas, (HTML.CanvasRenderingContext2D ctx) {
+      double sint = Math.sin(time);
+      double n = (sint + 1) / 2;
       ctx.rect(0, 0, d, d);
-      HTML.CanvasGradient grad = ctx.createLinearGradient(0, 0, d*n, d);
-      double cs1 = (360*n).floorToDouble();
-      double cs2 = (90*n).floorToDouble();
+      HTML.CanvasGradient grad = ctx.createLinearGradient(0, 0, d * n, d);
+      double cs1 = (360 * n).floorToDouble();
+      double cs2 = (90 * n).floorToDouble();
       grad.addColorStop(0, 'hsla($cs1, 100%, 40%, 1)');
       grad.addColorStop(0.2, 'black');
       grad.addColorStop(0.3, 'black');
@@ -78,24 +77,23 @@ class Utils
       ctx.fill();
     });
   }
-  
-  Texture createParticleTexture()
-  {
-    return createTextureFromCanvas(createParticleCanvas());
+
+  Texture createParticleTexture() {
+    return createTextureFromCanvas(createParticleCanvas(), false);
   }
 
-  HTML.CanvasElement createParticleCanvas()
-  {
+  HTML.CanvasElement createParticleCanvas() {
     int d = 64;
-    return createCanvas( null, (HTML.CanvasRenderingContext2D ctx){
-      int x = d~/2, y = d~/2;
+    return createCanvas(null, (HTML.CanvasRenderingContext2D ctx) {
+      int x = d ~/ 2,
+          y = d ~/ 2;
 
       var gradient = ctx.createRadialGradient(x, y, 1, x, y, 22);
       gradient.addColorStop(0, 'gray');
       gradient.addColorStop(1, 'black');
 
       ctx.fillStyle = gradient;
-      ctx.fillRect(0,0,d,d);
+      ctx.fillRect(0, 0, d, d);
 
       gradient = ctx.createRadialGradient(x, y, 1, x, y, 6);
       gradient.addColorStop(0, 'white');
@@ -108,165 +106,189 @@ class Utils
     }, d);
   }
 
-  
-  Mesh createQuad( Texture texture, int size)
-  {
+  Mesh createQuad(Texture texture, int size) {
     List<double> verts = [
-        -1.0*size, -1.0*size,  0.0,
-         1.0*size, -1.0*size,  0.0,
-         1.0*size,  1.0*size,  0.0,
-        -1.0*size,  1.0*size,  0.0
-      ];
-      
-    List<double> textureCoords = [
-        0.0, 0.0,
-        1.0, 0.0,
-        1.0, 1.0,
-        0.0, 1.0
-      ];
-      
-    List<int> vertexIndices = [
-        0, 1, 2,
-        0, 2, 3
-      ];
-      return new Mesh( new MeshData(vertices:verts, textureCoords:textureCoords, vertexIndices:vertexIndices), texture:texture);
+      -1.0 * size,
+      -1.0 * size,
+      0.0,
+      1.0 * size,
+      -1.0 * size,
+      0.0,
+      1.0 * size,
+      1.0 * size,
+      0.0,
+      -1.0 * size,
+      1.0 * size,
+      0.0
+    ];
+
+    List<double> textureCoords = [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0];
+
+    List<int> vertexIndices = [0, 1, 2, 0, 2, 3];
+    return new Mesh(new MeshData(
+        vertices: verts,
+        textureCoords: textureCoords,
+        vertexIndices: vertexIndices), texture: texture);
   }
-  
+
   void addSkycube(Texture cubeTexture) {
     ShaderProgram cm = chronosGL.createProgram(createCubeMapShader());
     Mesh m = createCube().multiplyVertices(512).createMesh();
     m.textureCube = cubeTexture;
     cm.addFollowCameraObject(m);
   }
-  
-  void addSkybox( String prefix, String suffix, String nx, String px, String nz, String pz, String ny, String py)
-  {
-    Texture tnx = textureCache.get(prefix+nx+suffix);
-    Texture tpx = textureCache.get(prefix+px+suffix);
-    Texture tnz = textureCache.get(prefix+nz+suffix);
-    Texture tpz = textureCache.get(prefix+pz+suffix);
-    Texture tny = textureCache.get(prefix+ny+suffix);
-    Texture tpy = textureCache.get(prefix+py+suffix);
+
+  void addSkybox(String prefix, String suffix, String nx, String px, String nz,
+      String pz, String ny, String py) {
+    Texture tnx = textureCache.get(prefix + nx + suffix);
+    Texture tpx = textureCache.get(prefix + px + suffix);
+    Texture tnz = textureCache.get(prefix + nz + suffix);
+    Texture tpz = textureCache.get(prefix + pz + suffix);
+    Texture tny = textureCache.get(prefix + ny + suffix);
+    Texture tpy = textureCache.get(prefix + py + suffix);
 
     Mesh skybox_nx = createQuad(tnx, 1004);
-    skybox_nx.setPos(-2.0,2.0,-1000.0);
+    skybox_nx.setPos(-2.0, 2.0, -1000.0);
     chronosGL.programBasic.addFollowCameraObject(skybox_nx);
 
     Mesh skybox_px = createQuad(tpx, 1004);
-    skybox_px.setPos(-2.0,2.0,1000.0);
-    skybox_px.rotY( Math.PI);
+    skybox_px.setPos(-2.0, 2.0, 1000.0);
+    skybox_px.rotY(Math.PI);
     chronosGL.programBasic.addFollowCameraObject(skybox_px);
 
     Mesh skybox_nz = createQuad(tnz, 1004);
-    skybox_nz.setPos(-1000.0,2.0,-2.0);
-    skybox_nz.rotY(0.5*Math.PI);
+    skybox_nz.setPos(-1000.0, 2.0, -2.0);
+    skybox_nz.rotY(0.5 * Math.PI);
     chronosGL.programBasic.addFollowCameraObject(skybox_nz);
 
     Mesh skybox_pz = createQuad(tpz, 1004);
-    skybox_pz.setPos(1000.0,2.0,-2.0);
-    skybox_pz.rotY( 1.5*Math.PI);
+    skybox_pz.setPos(1000.0, 2.0, -2.0);
+    skybox_pz.rotY(1.5 * Math.PI);
     chronosGL.programBasic.addFollowCameraObject(skybox_pz);
 
     Mesh skybox_ny = createQuad(tny, 1004);
-    skybox_ny.setPos( -2.0,-1000.0,-2.0);
-    skybox_ny.rotX( 1.5*Math.PI);
-    skybox_ny.rotZ( 1.5*Math.PI);
+    skybox_ny.setPos(-2.0, -1000.0, -2.0);
+    skybox_ny.rotX(1.5 * Math.PI);
+    skybox_ny.rotZ(1.5 * Math.PI);
     chronosGL.programBasic.addFollowCameraObject(skybox_ny);
 
     Mesh skybox_py = createQuad(tpy, 1004);
-    skybox_py.setPos( -2.0,1000.0,-2.0);
-    skybox_py.rotX( 0.5*Math.PI);
-    skybox_py.rotZ( 0.5*Math.PI);
+    skybox_py.setPos(-2.0, 1000.0, -2.0);
+    skybox_py.rotX(0.5 * Math.PI);
+    skybox_py.rotZ(0.5 * Math.PI);
     chronosGL.programBasic.addFollowCameraObject(skybox_py);
   }
-  
-  MeshData createIcosahedron( [int subdivisions=4]) {
+
+  MeshData createIcosahedron([int subdivisions = 4]) {
     return new Icosahedron(subdivisions);
   }
-  
-  MeshData createCube({double x:1.0, double y:1.0, double z:1.0, double uMin:0.0, double uMax:1.0, double vMin:0.0, double vMax:1.0}) {
-    return createCubeInternal(x:x,y:y,z:z, uMin:uMin, uMax:uMax, vMin:vMin, vMax:vMax);
-  }
-  
-  Mesh createTorusKnotMesh( {double radius:20.0, double tube:4.0, int segmentsR:128, int segmentsT:16, int p:2, int q:3, double heightScale:1.0, Texture texture}) {
-    return new Mesh(createTorusKnot(radius:radius, tube:tube, segmentsR:segmentsR, segmentsT:segmentsT, p:p, q:q, heightScale:heightScale), texture:texture);
-  }
-  
-  MeshData createTorusKnot( {double radius:20.0, double tube:4.0, int segmentsR:128, int segmentsT:16, int p:2, int q:3, double heightScale:1.0}) {
-    return createTorusKnotInternal( radius:radius, tube:tube, segmentsR:segmentsR, segmentsT:segmentsT, p:p, q:q, heightScale:heightScale);
-  }
-  
-  Mesh addCube( [TextureWrapper textureWrapper]) {
-    Texture t;
-    if( textureWrapper!=null)
-      t = textureWrapper.texture;
-    return chronosGL.programBasic.add( createCube().createMesh().setTexture(t));
+
+  MeshData createCube({double x: 1.0, double y: 1.0, double z: 1.0,
+      double uMin: 0.0, double uMax: 1.0, double vMin: 0.0, double vMax: 1.0}) {
+    return createCubeInternal(
+        x: x, y: y, z: z, uMin: uMin, uMax: uMax, vMin: vMin, vMax: vMax);
   }
 
-  Mesh addTorusKnot(  {double radius:20.0, double tube:4.0, int segmentsR:128, int segmentsT:16, int p:2, int q:3, double heightScale:1.0, TextureWrapper textureWrapper}) {
+  Mesh createTorusKnotMesh({double radius: 20.0, double tube: 4.0,
+      int segmentsR: 128, int segmentsT: 16, int p: 2, int q: 3,
+      double heightScale: 1.0, Texture texture}) {
+    return new Mesh(createTorusKnot(
+        radius: radius,
+        tube: tube,
+        segmentsR: segmentsR,
+        segmentsT: segmentsT,
+        p: p,
+        q: q,
+        heightScale: heightScale), texture: texture);
+  }
+
+  MeshData createTorusKnot({double radius: 20.0, double tube: 4.0,
+      int segmentsR: 128, int segmentsT: 16, int p: 2, int q: 3,
+      double heightScale: 1.0}) {
+    return createTorusKnotInternal(
+        radius: radius,
+        tube: tube,
+        segmentsR: segmentsR,
+        segmentsT: segmentsT,
+        p: p,
+        q: q,
+        heightScale: heightScale);
+  }
+
+  Mesh addCube([TextureWrapper textureWrapper]) {
     Texture t;
-    if( textureWrapper!=null)
-      t = textureWrapper.texture;
-    return chronosGL.programBasic.add( createTorusKnotMesh( radius:radius, tube:tube, segmentsR:segmentsR, segmentsT:segmentsT, p:p, q:q, heightScale:heightScale, texture: t));
+    if (textureWrapper != null) t = textureWrapper.texture;
+    return chronosGL.programBasic.add(createCube().createMesh().setTexture(t));
   }
-  
-  void addParticles(int numPoints, [int dimension=100]) {
-    addPointSprites( numPoints, createParticleTexture(), dimension);
+
+  Mesh addTorusKnot({double radius: 20.0, double tube: 4.0, int segmentsR: 128,
+      int segmentsT: 16, int p: 2, int q: 3, double heightScale: 1.0,
+      TextureWrapper textureWrapper}) {
+    Texture t;
+    if (textureWrapper != null) t = textureWrapper.texture;
+    return chronosGL.programBasic.add(createTorusKnotMesh(
+        radius: radius,
+        tube: tube,
+        segmentsR: segmentsR,
+        segmentsT: segmentsT,
+        p: p,
+        q: q,
+        heightScale: heightScale,
+        texture: t));
   }
-  
-  void addPointSprites(int numPoints, Texture texture, [int dimension=500]) {
+
+  void addParticles(int numPoints, [int dimension = 100]) {
+    addPointSprites(numPoints, createParticleTexture(), dimension);
+  }
+
+  void addPointSprites(int numPoints, Texture texture, [int dimension = 500]) {
     // TODO: make this asynchronous (async/await?)
     Math.Random rand = new Math.Random();
-    Float32List vertices = new Float32List(numPoints*3);
-    for( var i=0; i < vertices.length; i++)
-    {
-      vertices[i] = (rand.nextDouble()-0.5)*dimension;
+    Float32List vertices = new Float32List(numPoints * 3);
+    for (var i = 0; i < vertices.length; i++) {
+      vertices[i] = (rand.nextDouble() - 0.5) * dimension;
     }
-    MeshData md = new MeshData(vertices: vertices );
-    
+    MeshData md = new MeshData(vertices: vertices);
+
     ShaderProgram pssp = chronosGL.programs['point_sprites'];
-    if( pssp == null)
-        pssp = chronosGL.createProgram( createPointSpritesShader());
-    Mesh m= new Mesh( md, drawPoints:true, texture: texture);
+    if (pssp == null) pssp =
+        chronosGL.createProgram(createPointSpritesShader());
+    Mesh m = new Mesh(md, drawPoints: true, texture: texture);
     m.blend = true;
     m.depthWrite = false;
     m.blend_dFactor = 0x0301; // WebGLRenderingContext.ONE_MINUS_SRC_COLOR;
-    m.name = 'point_sprites_mesh_'+pssp.objects.length.toString();
-    pssp.add( m);
+    m.name = 'point_sprites_mesh_' + pssp.objects.length.toString();
+    pssp.add(m);
   }
-  
-  Future<Object> loadFile(String url, [bool binary=false])
-  {
+
+  Future<Object> loadFile(String url, [bool binary = false]) {
     Completer c = new Completer();
     HTML.HttpRequest hr = new HTML.HttpRequest();
     hr.open("GET", url);
-    if( binary)
-      hr.responseType = "arraybuffer";
-    hr.onLoadEnd.listen( (e) {
+    if (binary) hr.responseType = "arraybuffer";
+    hr.onLoadEnd.listen((e) {
       c.complete(hr.response);
     });
     hr.send();
     return c.future;
   }
 
-  Future<Object> loadBinaryFile(String url)
-  {
-    return loadFile( url, true);
+  Future<Object> loadBinaryFile(String url) {
+    return loadFile(url, true);
   }
 
-  Future<Object> loadJsonFile(String url)
-  {
+  Future<Object> loadJsonFile(String url) {
     Completer c = new Completer();
     HTML.HttpRequest hr = new HTML.HttpRequest();
     hr.open("GET", url);
-    hr.onLoadEnd.listen( (e) {
-      c.complete(JSON.decode( hr.responseText));
+    hr.onLoadEnd.listen((e) {
+      c.complete(JSON.decode(hr.responseText));
     });
     hr.send();
     return c.future;
   }
 
-  String getQueryVariable( String name) {
+  String getQueryVariable(String name) {
     String query = HTML.window.location.search.substring(1);
     List<String> vars = query.split("&");
     for (int i = 0; i < vars.length; i++) {
@@ -277,6 +299,4 @@ class Utils
     }
     return null;
   }
-    
 }
-


### PR DESCRIPTION
This is a change of the original behavior but it does not appear
to break the examples and it *is* the better default for canvases.

sorry - just realized that this also contained the automatic reformatting done by the DartEditor.